### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -305,6 +305,9 @@
 						<goals>
 							<goal>jar</goal>
 						</goals>
+						<configuration>
+                					<failOnError>false</failOnError>
+              					</configuration>
 					</execution>
 				</executions>
 			</plugin>


### PR DESCRIPTION
Bug with javadoc-plugin with java 11

Caused by: org.apache.maven.plugin.PluginExecutionException: Execution attach-javadocs of goal 
org.apache.maven.plugins:maven-javadoc-plugin:3.0.0:jar failed.